### PR TITLE
git-stats-colors 2.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-stats-colors",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Adds colors to the git-stats inputs.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Upgraded couleurs, removed ansi-parser as dependency
